### PR TITLE
feat: Push built Docker images to k8s staging infra with arm64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,17 @@ test:
 
 build-docker:
 	docker buildx build \
-		--output=type=docker \
+		--load \
 		--platform=linux/$(GOARCH) \
+		-t ${REPO}/${IMAGE}:latest \
+		-t ${REPO}/${IMAGE}:${TAG} \
+		--build-arg BUILDER=$(shell hack/setup-go.sh) \
+		--build-arg TAG=${TAG} .
+
+release-docker:
+	docker buildx build \
+		--push \
+		--platform=linux/amd64,linux/arm64 \
 		-t ${REPO}/${IMAGE}:latest \
 		-t ${REPO}/${IMAGE}:${TAG} \
 		--build-arg BUILDER=$(shell hack/setup-go.sh) \
@@ -31,4 +40,3 @@ build-server:
 
 build-client:
 	TAG=${TAG} hack/build-client.sh
-

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,15 +5,15 @@ options:
   dynamic_substitutions: true
 
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d'
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d"
     entrypoint: make
     env:
       - REPO=us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider
       - IMAGE=aws-encryption-provider
       - TAG=$_GIT_TAG
     args:
-      - build-docker
+      - release-docker
 
 substitutions:
-  _GIT_TAG: '12345'
-  _PULL_BASE_REF: 'master'
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "master"


### PR DESCRIPTION
From what I can tell, the Cloud Build job completes successfully; however, it never pushes the Docker images to the staging infra repos.

This PR adds a new `release-docker` make target to build and push the images to the staging infra repo. At that point, it should be much simpler to start tagging releases which can be promoted into `registry.k8s.io`.