### PR TITLE
bump go to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/aws-encryption-provider
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.2


### PR DESCRIPTION
On top of https://github.com/kubernetes-sigs/aws-encryption-provider/pull/160