### PR TITLE
fix: failing cloudbuild due to stale gcb image, update to use latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   dynamic_substitutions: true
 
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: make
     env:
       - REPO=us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider


### PR DESCRIPTION
Builds are failing as old gcb build image is no longer available, updating tag to use latest gcb image.

```
Error response from daemon: manifest for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d not found: manifest unknown: Failed to fetch "v20250116-2a05ea7e3d"
```

Failing build: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/aws-encryption-provider-push-images/2044177037203083264