### PR TITLE
fix: add health check timeouts

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -22,7 +22,7 @@ go version
 
 if ! which golangci-lint > /dev/null; then
     echo "Cannot find golangci-lint. Installing golangci-lint..."
-    GO111MODULE=on go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2
+    GO111MODULE=on go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 fi
 
 $(go env GOPATH)/bin/golangci-lint run --timeout=10m

--- a/pkg/cloud/mock.go
+++ b/pkg/cloud/mock.go
@@ -16,6 +16,7 @@ package cloud
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 )
@@ -45,6 +46,10 @@ type KMSMock struct {
 	defaultEncErr error
 	defaultDecOut *kms.DecryptOutput
 	defaultDecErr error
+
+	// Delay for simulating slow responses
+	encryptDelay time.Duration
+	decryptDelay time.Duration
 
 	// Conditional rules (evaluated in order)
 	encryptRules []EncryptRule
@@ -113,7 +118,27 @@ func (m *KMSMock) ClearRules() *KMSMock {
 	return m
 }
 
+// SetEncryptDelay sets a delay for Encrypt calls
+func (m *KMSMock) SetEncryptDelay(d time.Duration) *KMSMock {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.encryptDelay = d
+	return m
+}
+
 func (m *KMSMock) Encrypt(ctx context.Context, params *kms.EncryptInput, optFns ...func(*kms.Options)) (*kms.EncryptOutput, error) {
+	m.mutex.RLock()
+	delay := m.encryptDelay
+	m.mutex.RUnlock()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
@@ -128,7 +153,27 @@ func (m *KMSMock) Encrypt(ctx context.Context, params *kms.EncryptInput, optFns 
 	return m.defaultEncOut, m.defaultEncErr
 }
 
+// SetDecryptDelay sets a delay for Decrypt calls
+func (m *KMSMock) SetDecryptDelay(d time.Duration) *KMSMock {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.decryptDelay = d
+	return m
+}
+
 func (m *KMSMock) Decrypt(ctx context.Context, params *kms.DecryptInput, optFns ...func(*kms.Options)) (*kms.DecryptOutput, error) {
+	m.mutex.RLock()
+	delay := m.decryptDelay
+	m.mutex.RUnlock()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -91,8 +91,9 @@ func newPlugin(
 func (p *V1Plugin) Health() error {
 	recent, err := p.healthCheck.isRecentlyChecked()
 	if !recent {
-
-		_, err = p.Encrypt(context.Background(), &pb.EncryptRequest{Plain: []byte("foo")})
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err = p.Encrypt(ctx, &pb.EncryptRequest{Plain: []byte("foo")})
 		p.healthCheck.RecordErr(err)
 		if err != nil {
 			zap.L().Warn("health check failed", zap.Error(err))

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -392,3 +392,26 @@ func TestHealthManyRequests(t *testing.T) {
 		}
 	}
 }
+
+func TestHealthTimeout(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	c := &cloud.KMSMock{}
+	c.SetEncryptResp("foo", nil)
+	c.SetEncryptDelay(6 * time.Second) // longer than 5s timeout
+
+	sharedHealthCheck := NewSharedHealthCheck(DefaultHealthCheckPeriod, DefaultErrcBufSize)
+	go sharedHealthCheck.Start()
+	defer sharedHealthCheck.Stop()
+
+	p := New(key, c, nil, sharedHealthCheck)
+
+	err := p.Health()
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected deadline exceeded error, got: %v", err)
+	}
+}

--- a/pkg/plugin/plugin_v2.go
+++ b/pkg/plugin/plugin_v2.go
@@ -90,13 +90,15 @@ func newPluginV2(
 func (p *V2Plugin) Health() error {
 	recent, err := p.healthCheck.isRecentlyChecked()
 	if !recent {
-		encResult, err := p.Encrypt(context.Background(), &pb.EncryptRequest{Plaintext: []byte("foo")})
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		encResult, err := p.Encrypt(ctx, &pb.EncryptRequest{Plaintext: []byte("foo")})
 		p.healthCheck.RecordErr(err)
 		if err != nil {
 			zap.L().Warn("health check failed at encryption", zap.Error(err))
 			return err
 		}
-		_, err = p.Decrypt(context.Background(), &pb.DecryptRequest{Ciphertext: encResult.Ciphertext})
+		_, err = p.Decrypt(ctx, &pb.DecryptRequest{Ciphertext: encResult.Ciphertext})
 		p.healthCheck.RecordErr(err)
 		if err != nil {
 			zap.L().Warn("health check failed at decryption", zap.Error(err))

--- a/pkg/plugin/plugin_v2_test.go
+++ b/pkg/plugin/plugin_v2_test.go
@@ -444,3 +444,50 @@ func TestHealthManyRequestsV2(t *testing.T) {
 		}
 	}
 }
+
+func TestHealthTimeoutV2(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	c := &cloud.KMSMock{}
+	c.SetEncryptResp("foo", nil)
+	c.SetEncryptDelay(6 * time.Second) // longer than 5s timeout
+
+	sharedHealthCheck := NewSharedHealthCheck(DefaultHealthCheckPeriod, DefaultErrcBufSize)
+	go sharedHealthCheck.Start()
+	defer sharedHealthCheck.Stop()
+
+	p := NewV2(key, c, nil, sharedHealthCheck)
+
+	err := p.Health()
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected deadline exceeded error, got: %v", err)
+	}
+}
+
+func TestHealthDecryptTimeoutV2(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	c := &cloud.KMSMock{}
+	c.SetEncryptResp("foo", nil)
+	c.SetDecryptResp("foo", nil)
+	c.SetDecryptDelay(6 * time.Second) // longer than 5s timeout
+
+	sharedHealthCheck := NewSharedHealthCheck(DefaultHealthCheckPeriod, DefaultErrcBufSize)
+	go sharedHealthCheck.Start()
+	defer sharedHealthCheck.Stop()
+
+	p := NewV2(key, c, nil, sharedHealthCheck)
+
+	err := p.Health()
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected deadline exceeded error, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Summary
Adding timeouts to health checks to prevent unbounded wait times.

### Testing
- `make test`
```
    --- PASS: TestListenAndServe/:8080 (3.00s)
PASS
coverage: 66.7% of statements
ok      sigs.k8s.io/aws-encryption-provider/pkg/server  (cached)        coverage: 66.7% of statements
?       sigs.k8s.io/aws-encryption-provider/pkg/version [no test files]
=== RUN   TestEncrypt
--- PASS: TestEncrypt (0.02s)
=== RUN   TestDecrypt
--- PASS: TestDecrypt (0.01s)
PASS
coverage: [no statements]
ok      sigs.k8s.io/aws-encryption-provider/test/integration    (cached)        coverage: [no statements]
```
