### PR TITLE
Bumping gorunner image tag in Dockerfile for CVE mitigation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.25.9-gcc
-ARG BASE_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.18.0-eks-1-35-latest
+ARG BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.25.9.2023
 
 FROM --platform=$BUILDPLATFORM ${BUILDER} AS build
 WORKDIR /go/src/sigs.k8s.io/aws-encryption-provider


### PR DESCRIPTION
Bumping go-runner image tag in Dockerfile for CVE mitigations: 
```
CVE-2026-27139
CVE-2026-27142
CVE-2026-32288
CVE-2026-32289
CVE-2026-32282
CVE-2026-32281
CVE-2026-32280
CVE-2026-25679
CVE-2026-32283
```

