### PR TITLE
Fix index-out-of-bounds panic on empty ciphertext in Decrypt

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -15,6 +15,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -177,6 +178,10 @@ func (p *V1Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 	zap.L().Debug("starting decrypt operation")
 
 	startTime := time.Now()
+
+	if len(request.Cipher) == 0 {
+		return nil, errors.New("invalid empty ciphertext")
+	}
 	if string(request.Cipher[0]) == kmsplugin.StorageVersion {
 		request.Cipher = request.Cipher[1:]
 	}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -415,3 +415,49 @@ func TestHealthTimeout(t *testing.T) {
 		t.Fatalf("expected deadline exceeded error, got: %v", err)
 	}
 }
+
+func TestDecryptEmptyCipher(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	c := &cloud.KMSMock{}
+	ctx := context.Background()
+
+	sharedHealthCheck := NewSharedHealthCheck(DefaultHealthCheckPeriod, DefaultErrcBufSize)
+	go sharedHealthCheck.Start()
+	defer sharedHealthCheck.Stop()
+
+	p := New(key, c, nil, sharedHealthCheck)
+
+	dReq := &pb.DecryptRequest{Cipher: []byte{}}
+	_, err := p.Decrypt(ctx, dReq)
+
+	if err == nil {
+		t.Fatal("expected error for empty ciphertext, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid empty ciphertext") {
+		t.Fatalf("expected 'invalid empty ciphertext' error, got: %v", err)
+	}
+}
+
+func TestDecryptNilCipher(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	c := &cloud.KMSMock{}
+	ctx := context.Background()
+
+	sharedHealthCheck := NewSharedHealthCheck(DefaultHealthCheckPeriod, DefaultErrcBufSize)
+	go sharedHealthCheck.Start()
+	defer sharedHealthCheck.Stop()
+
+	p := New(key, c, nil, sharedHealthCheck)
+
+	dReq := &pb.DecryptRequest{Cipher: nil}
+	_, err := p.Decrypt(ctx, dReq)
+
+	if err == nil {
+		t.Fatal("expected error for nil ciphertext, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid empty ciphertext") {
+		t.Fatalf("expected 'invalid empty ciphertext' error, got: %v", err)
+	}
+}

--- a/pkg/plugin/plugin_v2.go
+++ b/pkg/plugin/plugin_v2.go
@@ -15,6 +15,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -181,6 +182,10 @@ func (p *V2Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 	zap.L().Debug("starting decrypt operation")
 
 	startTime := time.Now()
+
+	if len(request.Ciphertext) == 0 {
+		return nil, errors.New("invalid empty ciphertext")
+	}
 	storageVersion := kmsplugin.KMSStorageVersion(request.Ciphertext[0])
 	switch storageVersion {
 	case kmsplugin.KMSStorageVersionV2:

--- a/pkg/plugin/plugin_v2_test.go
+++ b/pkg/plugin/plugin_v2_test.go
@@ -491,3 +491,49 @@ func TestHealthDecryptTimeoutV2(t *testing.T) {
 		t.Fatalf("expected deadline exceeded error, got: %v", err)
 	}
 }
+
+func TestDecryptEmptyCiphertextV2(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	c := &cloud.KMSMock{}
+	ctx := context.Background()
+
+	sharedHealthCheck := NewSharedHealthCheck(DefaultHealthCheckPeriod, DefaultErrcBufSize)
+	go sharedHealthCheck.Start()
+	defer sharedHealthCheck.Stop()
+
+	p := NewV2(key, c, nil, sharedHealthCheck)
+
+	dReq := &pb.DecryptRequest{Ciphertext: []byte{}}
+	_, err := p.Decrypt(ctx, dReq)
+
+	if err == nil {
+		t.Fatal("expected error for empty ciphertext, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid empty ciphertext") {
+		t.Fatalf("expected 'invalid empty ciphertext' error, got: %v", err)
+	}
+}
+
+func TestDecryptNilCiphertextV2(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	c := &cloud.KMSMock{}
+	ctx := context.Background()
+
+	sharedHealthCheck := NewSharedHealthCheck(DefaultHealthCheckPeriod, DefaultErrcBufSize)
+	go sharedHealthCheck.Start()
+	defer sharedHealthCheck.Stop()
+
+	p := NewV2(key, c, nil, sharedHealthCheck)
+
+	dReq := &pb.DecryptRequest{Ciphertext: nil}
+	_, err := p.Decrypt(ctx, dReq)
+
+	if err == nil {
+		t.Fatal("expected error for nil ciphertext, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid empty ciphertext") {
+		t.Fatalf("expected 'invalid empty ciphertext' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Added a length check on the ciphertext slice before accessing its first
element in both V1 and V2 `Decrypt` methods.

If `request.Cipher` (V1) or `request.Ciphertext` (V2) is empty, the
current code panics with an index-out-of-bounds error when trying to
read the storage version byte at index `[0]`. This can occur if a
malformed or empty decrypt request is received.

## Changes
- `pkg/plugin/plugin.go` — return `fmt.Errorf("invalid empty ciphertext")` if `request.Cipher` is empty
- `pkg/plugin/plugin_v2.go` — same guard for `request.Ciphertext`
- `pkg/plugin/plugin_test.go` — unit test for V1 empty ciphertext path
- `pkg/plugin/plugin_v2_test.go` — unit test for V2 empty ciphertext path

## Testing
`go test ./pkg/plugin/... -run TestDecryptEmptyCipher`