### PR TITLE
Add External key store proxy communication failure to UserInduced errors

### DIFF
--- a/pkg/kmsplugin/kms.go
+++ b/pkg/kmsplugin/kms.go
@@ -105,7 +105,8 @@ func ParseError(err error) (errorType KMSErrorType) {
 		}
 	// Sometimes this error message is returned as part of KMSInvalidStateException or KMSInternalException
 	case (&kmstypes.KMSInternalException{}).ErrorCode():
-		if strings.Contains(ae.ErrorMessage(), "AWS KMS rejected the request because the external key store proxy did not respond in time. Retry the request. If you see this error repeatedly, report it to your external key store proxy administrator") {
+		if strings.Contains(ae.ErrorMessage(), "AWS KMS rejected the request because the external key store proxy did not respond in time. Retry the request. If you see this error repeatedly, report it to your external key store proxy administrator") ||
+			strings.Contains(ae.ErrorMessage(), "AWS KMS cannot communicate with the external key store proxy") {
 			return KMSErrorTypeUserInduced
 		}
 	}

--- a/pkg/kmsplugin/kms_test.go
+++ b/pkg/kmsplugin/kms_test.go
@@ -114,6 +114,11 @@ func TestParseError(t *testing.T) {
 			expected: KMSErrorTypeUserInduced,
 		},
 		{
+			name:     "KMSInternalException with external key store proxy communication failure",
+			err:      &mockAPIError{code: (&types.KMSInternalException{}).ErrorCode(), message: "AWS KMS cannot communicate with the external key store proxy"},
+			expected: KMSErrorTypeUserInduced,
+		},
+		{
 			name:     "KMSInternalException with other message",
 			err:      &mockAPIError{code: (&types.KMSInternalException{}).ErrorCode(), message: "Some other internal error"},
 			expected: KMSErrorTypeOther,


### PR DESCRIPTION
Categorize 'AWS KMS cannot communicate with the external key store proxy' error message as KMSErrorTypeUserInduced in the KMSInternalException case. Added corresponding test case.